### PR TITLE
[mod] Splash 뷰 다음 항상 온보딩 뜨도록

### DIFF
--- a/hearo/hearo.xcodeproj/xcuserdata/kimhyegyu.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/hearo/hearo.xcodeproj/xcuserdata/kimhyegyu.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -16,8 +16,8 @@
             endingColumnNumber = "9223372036854775807"
             startingLineNumber = "158"
             endingLineNumber = "158"
-            landmarkName = "unknown"
-            landmarkType = "0">
+            landmarkName = "requestMicrophonePermission()"
+            landmarkType = "7">
          </BreakpointContent>
       </BreakpointProxy>
    </Breakpoints>

--- a/hearo/hearo/Application/hearoApp.swift
+++ b/hearo/hearo/Application/hearoApp.swift
@@ -92,8 +92,9 @@ final class AppRootManager: ObservableObject {
  
     // 스플래시 끝났을 때 호출
     func determineNextRoot() {
-        let hasSeenOnboarding = UserDefaults.standard.bool(forKey: "hasSeenOnboarding")
-        self.currentRoot = hasSeenOnboarding ? .home : .startOnboarding
+//        let hasSeenOnboarding = UserDefaults.standard.bool(forKey: "hasSeenOnboarding")
+//        self.currentRoot = hasSeenOnboarding ? .home : .startOnboarding
+        self.currentRoot = .startOnboarding
     }
     
     // 라이브 액티비티 시작 메서드

--- a/hearo/hearo/Sources/Presentations/OnBoarding/ViewModel/OnboardingViewModel.swift
+++ b/hearo/hearo/Sources/Presentations/OnBoarding/ViewModel/OnboardingViewModel.swift
@@ -16,7 +16,7 @@ class OnboardingViewModel: ObservableObject {
     }
 
     func moveToHome() {
-        UserDefaults.standard.set(true, forKey: "hasSeenOnboarding")
+//        UserDefaults.standard.set(true, forKey: "hasSeenOnboarding")
         appRootManager.currentRoot = .home
     }
 }


### PR DESCRIPTION
<!--[#이슈번호] Title
ex) [#1] PR Templete 생성
타이틀 양식 참고하고 지우기 !!-->
## 📝 작업 내용
- 스플래시 뷰 다음에 항상 온보딩 뷰가 뜨도록 했습니다! 

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
### 바뀐 부분 설명
`[hearoApp.swift]`
- final class AppRootManager 부분
전 : 
<img width="557" alt="image" src="https://github.com/user-attachments/assets/129a9056-bb20-432b-b307-45a7677bc56b">

후 : 
<img width="606" alt="image" src="https://github.com/user-attachments/assets/2be45e23-0eac-4aae-b526-6438b9c2732a">


`[OnboardingViewModel.swift]`
전 : 
<img width="508" alt="image" src="https://github.com/user-attachments/assets/50db9843-9546-460b-95aa-9bb7360a0027">

후 : 
<img width="483" alt="image" src="https://github.com/user-attachments/assets/d8658ec4-556d-4ffd-8583-30033fe1f03e">



